### PR TITLE
Ignore unavailable tracks

### DIFF
--- a/lib/playlist.js
+++ b/lib/playlist.js
@@ -3,7 +3,6 @@ module.exports = function (spotify) {
   var Track = require("./track")(spotify);
   var firebaseRef = require("./firebase").ref.child("playlist");
   var Url = require("url");
-  var _ = require("lodash");
 
   var queue   = [],
       tracks  = [],
@@ -86,10 +85,9 @@ module.exports = function (spotify) {
   function loadPlaylist(playlist){
     firebaseRef.child("name").set(playlist.name);
 
-    var availableTracks = _.filter(playlist.getTracks(), function(track) {
-      return track.availability !== 0 && !localFileRegex.test(track.link);
+    var availableTracks = playlist.getTracks().filter(function(track) {
+      return !localFileRegex.test(track.link) && track.availability === 1;
     });
-
     tracks = availableTracks.map(function(track) {
       return track.link;
     });

--- a/lib/playlist.js
+++ b/lib/playlist.js
@@ -3,6 +3,7 @@ module.exports = function (spotify) {
   var Track = require("./track")(spotify);
   var firebaseRef = require("./firebase").ref.child("playlist");
   var Url = require("url");
+  var _ = require("lodash");
 
   var queue   = [],
       tracks  = [],
@@ -84,9 +85,15 @@ module.exports = function (spotify) {
 
   function loadPlaylist(playlist){
     firebaseRef.child("name").set(playlist.name);
-    tracks = playlist.getTracks().map(function(track){
-      return (localFileRegex.test(track.link)) ? null : track.link;
+
+    var availableTracks = _.filter(playlist.getTracks(), function(track) {
+      return track.availability !== 0 && !localFileRegex.test(track.link);
     });
+
+    tracks = availableTracks.map(function(track) {
+      return track.link;
+    });
+
     firebaseRef.child("tracks").set(tracks);
     populateQueue();
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dotenv": "^0.5.1",
     "express": "^4.11.2",
     "firebase": "^2.1.2",
+    "lodash": "^3.10.1",
     "loudness": "^0.2.2",
     "node-spotify": "^0.7.1",
     "scribble": "0.0.5"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "dotenv": "^0.5.1",
     "express": "^4.11.2",
     "firebase": "^2.1.2",
-    "lodash": "^3.10.1",
     "loudness": "^0.2.2",
     "node-spotify": "^0.7.1",
     "scribble": "0.0.5"


### PR DESCRIPTION
Spotify hides unavailable tracks but they are still attached to the playlist. Fix prevents Firebase from being populated with unavailable tracks.

Fixes https://github.com/himynameisjonas/spotbot/issues/6