### PR TITLE
Allow disabling repeat on playlists

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -93,7 +93,7 @@ module.exports = function (spotify, queue, playlist) {
       }
     } else {
       console.log("No track to play. Trying again in 1 second");
-      spotify.player.pause();
+      pause();
       setTimeout(playNext, 1000);
     }
   }

--- a/lib/playlist.js
+++ b/lib/playlist.js
@@ -7,6 +7,7 @@ module.exports = function (spotify) {
   var queue   = [],
       tracks  = [],
       shuffle = false,
+      repeat = true,
       playlistRegex = /spotify:user:(?:[A-Za-z0-9_-]*):playlist:(?:[A-Za-z0-9]*)/,
       albumRegex = /spotify:album:(?:[A-Za-z0-9_-]*)/,
       name,
@@ -30,6 +31,14 @@ module.exports = function (spotify) {
     }
   });
 
+  firebaseRef.child("repeat").on("value", function(data){
+    if (data.val() !== null) {
+      repeat = data.val();
+    } else {
+      data.ref().set(true);
+    }
+  });
+
   function next(){
     var uri;
     if (queue.length) {
@@ -37,7 +46,7 @@ module.exports = function (spotify) {
       if (uri) {
         return new Track(uri);
       }
-    } else if(tracks.length) {
+    } else if(tracks.length && repeat) {
       populateQueue();
       uri = queue.shift();
       if (uri) {


### PR DESCRIPTION
Add a repeat property to firebase so that clients can decide if it should repeat playlists once they have reached the end. It defaults to true so it doesn't change the behavior of current clients.